### PR TITLE
Add option to include shell completions.

### DIFF
--- a/src/runme/devcontainer-feature.json
+++ b/src/runme/devcontainer-feature.json
@@ -11,6 +11,11 @@
             ],
             "default": "latest",
             "description": "Select or enter a Runme version to install"
+        },
+        "completions": {
+            "default": true,
+            "description": "Attempt to install shell completions for bash & zsh.",
+            "type": "boolean"
         }
     },
     "installsAfter": [

--- a/src/runme/install.sh
+++ b/src/runme/install.sh
@@ -23,4 +23,18 @@ $nanolayer_location \
     "ghcr.io/devcontainers-contrib/features/npm-package:1.0.3" \
     --option package='runme'
 
+# Need a new shell to pick up NVM paths
+bash -i << EOF
+if [ "$COMPLETIONS" = "true" ]; then {
+  # runme bash completion
+  mkdir -p /etc/bas_completion.d
+  runme completion bash > /etc/bash_completion.d/runme
+
+  # runme zsh completion
+  if [ -e "/usr/share/zsh/vendor-completions" ]; then 
+    runme completion zsh > /usr/share/zsh/vendor-completions/_runme
+  fi
+} fi
+EOF
+
 echo 'Done!'

--- a/src/runme/install.sh
+++ b/src/runme/install.sh
@@ -27,7 +27,7 @@ $nanolayer_location \
 bash -i << EOF
 if [ "$COMPLETIONS" = "true" ]; then {
   # runme bash completion
-  mkdir -p /etc/bas_completion.d
+  mkdir -p /etc/bash_completion.d
   runme completion bash > /etc/bash_completion.d/runme
 
   # runme zsh completion


### PR DESCRIPTION
While installing the runme cli, also generate the shell _completions_ for `bash` and `zsh`.